### PR TITLE
[#4] 뉴스 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "newrelic": "^11.23.2",
     "node-fetch": "2.7.0",
     "node-schedule": "^2.1.1",
+    "reflect-metadata": "^0.2.2",
     "tslib": "^2.6.3",
     "uuid": "^9.0.1",
     "winston": "^3.13.1",
@@ -42,7 +43,7 @@
   },
   "devDependencies": {
     "@swc/cli": "^0.1.65",
-    "@swc/core": "^1.7.3",
+    "@swc/core": "^1.7.6",
     "@swc/helpers": "^0.5.12",
     "@types/compression": "^1.7.5",
     "@types/cors": "^2.8.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,10 +89,10 @@ importers:
     devDependencies:
       '@swc/cli':
         specifier: ^0.1.65
-        version: 0.1.65(@swc/core@1.7.3(@swc/helpers@0.5.12))(chokidar@3.6.0)
+        version: 0.1.65(@swc/core@1.7.6(@swc/helpers@0.5.12))(chokidar@3.6.0)
       '@swc/core':
-        specifier: ^1.7.3
-        version: 1.7.3(@swc/helpers@0.5.12)
+        specifier: ^1.7.6
+        version: 1.7.6(@swc/helpers@0.5.12)
       '@swc/helpers':
         specifier: ^0.5.12
         version: 0.5.12
@@ -542,9 +542,6 @@ packages:
   '@types/form-data@0.0.33':
     resolution: {integrity: sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==}
 
-  '@types/geojson@7946.0.14':
-    resolution: {integrity: sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==}
-
   '@types/hpp@0.2.6':
     resolution: {integrity: sha512-6gn1RuHA1/XFCVCqCkSV+AWy07YwtGg4re4SHhLMoiARTg9XlrbYMtVR+Uvws0VlERXzzcA+1UYvxEV6O+sgPg==}
 
@@ -589,9 +586,6 @@ packages:
 
   '@types/node@10.17.60':
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
-
-  '@types/node@20.14.15':
-    resolution: {integrity: sha512-Fz1xDMCF/B00/tYSVMlmK7hVeLh7jE5f3B7X1/hmV0MJBwE27KlS7EvD/Yp+z1lm8mVhwV5w+n8jOZG8AfTlKw==}
 
   '@types/node@22.0.0':
     resolution: {integrity: sha512-VT7KSYudcPOzP5Q0wfbowyNLaVR8QWUdw+088uFWwfvpY6uCWaXpqV6ieLAu9WBcnTa7H4Z5RLK8I5t2FuOcqw==}
@@ -1021,10 +1015,6 @@ packages:
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
-
-  crypto@1.0.1:
-    resolution: {integrity: sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==}
-    deprecated: This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.
 
   date-format@4.0.14:
     resolution: {integrity: sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==}
@@ -1807,10 +1797,6 @@ packages:
   make-fetch-happen@13.0.1:
     resolution: {integrity: sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==}
     engines: {node: ^16.14.0 || >=18.0.0}
-
-  mariadb@3.3.1:
-    resolution: {integrity: sha512-L8bh4iuZU3J8H7Co7rQ6OY9FDLItAN1rGy8kPA7Dyxo8AiHADuuONoypKKp1pE09drs6e5LR7UW9luLZ/A4znA==}
-    engines: {node: '>= 14'}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -2642,9 +2628,6 @@ packages:
   undefsafe@2.0.5:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   undici-types@6.11.1:
     resolution: {integrity: sha512-mIDEX2ek50x0OlRgxryxsenE5XaQD4on5U2inY7RApK3SOJpofyw7uW2AyfMKkhAxXIceo2DeWGVGwyvng1GNQ==}
 
@@ -3232,8 +3215,6 @@ snapshots:
     dependencies:
       '@types/node': 8.10.66
 
-  '@types/geojson@7946.0.14': {}
-
   '@types/hpp@0.2.6':
     dependencies:
       '@types/express': 4.17.21
@@ -3278,10 +3259,6 @@ snapshots:
       '@types/node': 22.0.0
 
   '@types/node@10.17.60': {}
-
-  '@types/node@20.14.15':
-    dependencies:
-      undici-types: 5.26.5
 
   '@types/node@22.0.0':
     dependencies:
@@ -3785,8 +3762,6 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  crypto@1.0.1: {}
 
   date-format@4.0.14: {}
 
@@ -4658,14 +4633,6 @@ snapshots:
       - supports-color
     optional: true
 
-  mariadb@3.3.1:
-    dependencies:
-      '@types/geojson': 7946.0.14
-      '@types/node': 20.14.15
-      denque: 2.1.0
-      iconv-lite: 0.6.3
-      lru-cache: 10.4.3
-
   media-typer@0.3.0: {}
 
   memory-pager@1.5.0:
@@ -5536,8 +5503,6 @@ snapshots:
   typescript@5.5.4: {}
 
   undefsafe@2.0.5: {}
-
-  undici-types@5.26.5: {}
 
   undici-types@6.11.1: {}
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -25,6 +25,7 @@ export default class API {
     setController() {
         this.app.use('/user', controllers.user)
         this.app.use('/community', controllers.community)
+        this.app.use('/news', controllers.news)
     }
 
     setPostMiddleware() {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,9 +1,8 @@
-// import * as db from './models/connector'
+import * as db from './models/connector'
 import API from './api'
 import { logger } from './utils/logger'
 ;(async () => {
-    //TODO : mongoDB 연결
-    // await db.connect()
+    await db.connect()
     const api = new API()
 
     api.listen()
@@ -11,7 +10,7 @@ import { logger } from './utils/logger'
     async function shutdown() {
         logger.info('gracefully shutdown')
         await Promise.all([api.close])
-        //await db.close()
+        await db.close()
         logger.info('shutdown complete')
         process.exit()
     }

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,7 +1,9 @@
 import user from './user'
 import community from './community'
+import news from './news'
 
 export default {
     user,
     community,
+    news,
 }

--- a/src/controllers/news.ts
+++ b/src/controllers/news.ts
@@ -1,0 +1,79 @@
+import 'reflect-metadata'
+import express, { Router, Request, Response } from 'express'
+import { NewsModel } from '@/models/news'
+import { verifyUser } from '@/middlewares/user'
+import { conn } from '@/config'
+
+const router: Router = express.Router()
+
+router.use(verifyUser)
+
+router.get('/date', async (req: Request, res: Response) => {
+    const page = Number(req.query.page || 1)
+    const limit = Number(req.query.size || 6)
+    const date = req.body.date
+    const result = await NewsModel.findByDate(date, page, limit)
+
+    const newsResult = result.docs.map(news => ({ ...news.toJSON() }))
+    res.status(200).json({
+        news: newsResult,
+        page: {
+            totalDocs: result.totalDocs,
+            totalPages: result.totalPages,
+            hasNextPage: result.hasNextPage,
+            hasPrevPage: result.hasPrevPage,
+            page: result.page,
+            limit: result.limit,
+        },
+    })
+})
+
+router.get('/:newsId', async (req: Request, res: Response) => {
+    const news = await NewsModel.findById(req.params.newsId)
+    const params = [req.params.newsId, req.params.newsId, req.user._id]
+    ;(await conn).query('update User set log = if(log IS NULL, json_array(?), json_merge_preserve(log, json_array(?))) where _id = ?', params)
+    res.status(200).json({
+        _id: news._id,
+        title: news.title,
+        title_trans: news.title_trans,
+        category: news.category,
+        article: news.article,
+        article_trans: news.article_trans,
+        url: news.url,
+        urlToImage: news.urlToImage,
+        publishedAt: news.publishedAt,
+        source: news.source,
+        author: news.author,
+        embedding: news.embedding,
+    })
+})
+
+router.get('/date/:category', async (req: Request, res: Response) => {
+    const page = Number(req.query.page || 1)
+    const limit = Number(req.query.size || 6)
+    const date = req.body.date
+    const category = req.params.category
+    const result = await NewsModel.findByDateAndCategory(date, category, page, limit)
+
+    const newsResult = result.docs.map(news => ({ ...news.toJSON() }))
+    res.status(200).json({
+        news: newsResult,
+        page: {
+            totalDocs: result.totalDocs,
+            totalPages: result.totalPages,
+            hasNextPage: result.hasNextPage,
+            hasPrevPage: result.hasPrevPage,
+            page: result.page,
+            limit: result.limit,
+        },
+    })
+})
+
+router.get('/:newsId/article', async (req: Request, res: Response) => {
+    const news = await NewsModel.findById(req.params.newsId)
+    res.status(200).json({
+        article: news.article,
+    })
+})
+
+export default router

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -51,16 +51,15 @@ router.post('/signin', async (req: Request, res: Response) => {
 
 router.get('/detail', verifyUser, async (req: Request, res: Response) => {
     res.status(200).json({
-        _id: req.user._id,
         oauthId: req.user.oauthId,
         nickname: req.user.nickname,
         name: req.user.name,
-        password: req.user.password,
     })
 })
 
 router.put('/detail', verifyUser, async (req: Request, res: Response) => {
-    const params = [req.body.nickname, req.body.password]
+    const hash = await createHashPasswd(req.body.password, req.user.salt)
+    const params = [req.body.nickname, hash]
     try {
         ;(await conn).query('update User set nickname=?, password=?', params)
     } catch (err) {

--- a/src/models/connector.ts
+++ b/src/models/connector.ts
@@ -9,17 +9,12 @@ export async function connect() {
     } catch (err) {
         throw new Error('DB connection error')
     }
-    try {
-        logger.info(`Successfully connect MySQL DB.`)
-    } catch (err) {
-        throw new Error('MySQL DB connection failed')
-    }
 }
 
 export async function close() {
     try {
         await mongoose.connection.close(false)
-        logger.info(`successfully close DB`)
+        logger.info(`successfully close MongoDB connection. DB_NAME=${DB_NAME}`)
     } catch (err) {
         throw new Error('DB closing error')
     }

--- a/src/models/news.ts
+++ b/src/models/news.ts
@@ -1,0 +1,108 @@
+import mongoose, { PaginateOptions } from 'mongoose'
+import { TimeStamps } from '@typegoose/typegoose/lib/defaultClasses'
+import { getModelForClass, prop, ReturnModelType, plugin } from '@typegoose/typegoose'
+import mongoosePaginate from 'mongoose-paginate-v2'
+
+@plugin(mongoosePaginate)
+export class News extends TimeStamps {
+    static paginate: mongoose.PaginateModel<typeof News>['paginate']
+
+    public _id: mongoose.Types.ObjectId
+
+    @prop()
+    public title: string
+
+    @prop()
+    public title_trans: string // 제목 번역
+
+    @prop()
+    public category: string // 카테고리
+
+    @prop()
+    public article: string //원문
+
+    @prop()
+    public article_trans: string
+
+    @prop()
+    public url: string
+
+    @prop()
+    public urlToImage: string // 기사 사진
+
+    @prop()
+    public publishedAt: string
+
+    @prop()
+    public source: string // 신문사 or Google News
+
+    @prop()
+    public author: string // 기자 or 신문사
+
+    @prop()
+    public embedding: object // 임베딩 벡터
+
+    public toJSON(): object {
+        return {
+            _id: this._id,
+            title: this.title,
+            title_trans: this.title_trans,
+            category: this.category,
+            article: this.article,
+            article_trans: this.article_trans,
+            url: this.url,
+            urlToImage: this.urlToImage,
+            publishedAt: this.publishedAt,
+            source: this.source,
+            author: this.author,
+            embedding: this.embedding,
+        }
+    }3
+
+    public static async findById(this: ReturnModelType<typeof News>, newsId: string): Promise<News> {
+        const news = await this.findOne({ _id: newsId })
+        if (news) {
+            return news
+        } else {
+            throw new Error('NewsNotFound')
+        }
+    }
+
+    public static async findByDate(
+        this: ReturnModelType<typeof News>,
+        date: string,
+        page: number,
+        limit: number,
+    ): Promise<mongoose.PaginateResult<mongoose.PaginateDocument<News, object, PaginateOptions>>> {
+        return await this.paginate(
+            { publishedAt: { $regex: `^${date}` } },
+            {
+                page: page,
+                limit: limit,
+            },
+        )
+    }
+
+    public static async findByDateAndCategory(
+        this: ReturnModelType<typeof News>,
+        date: string,
+        category: string,
+        page: number,
+        limit: number,
+    ): Promise<mongoose.PaginateResult<mongoose.PaginateDocument<News, object, PaginateOptions>>> {
+        return await this.paginate(
+            { publishedAt: { $regex: `^${date}` }, category: category },
+            {
+                page: page,
+                limit: limit,
+            },
+        )
+    }
+}
+
+export const NewsModel = getModelForClass(News, {
+    schemaOptions: {
+        toJSON: { virtuals: true },
+        toObject: { virtuals: true },
+    },
+})

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -14,4 +14,6 @@ export class User extends TimeStamps {
     public password: string
 
     public salt: string
+
+    public log: JSON
 }


### PR DESCRIPTION
## 🎯 기능 개요
- 뉴스 기능 구현
- 비밀번호 암호화 중 빠진 부분 보충

## 🏗 구현 상세 및 설계 문서
- 날짜별, 카테고리별 뉴스 불러오기
- 특정 뉴스의 정보 확인하고, 확인한 유저의 로그에 해당 뉴스 id 기록
- 비밀번호 수정 시 DB에 비밀번호를 그대로 저장하는걸 해시화 해서 저장하도록 수정
- [API 설계](https://wide-hardhat-c5f.notion.site/API-bc1d966bf9e74a0fb6c42becb2851603?pvs=4)

## 🧪 테스트 계획 및 결과
- 테스트 코드 없음

## 🔍 사이드 이펙트 분석
- 사이드 이펙트 없음

## ✅ 체크리스트
- [x] 기능별 API 작성
- [x] MongoDB 연결 체크
- [x] news 모델

## 📝 추가 노트
- 없음
